### PR TITLE
fix could not be found in any version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "type": "yii2-extension",
     "keywords": ["yii2","extension"],
     "license": "MIT",
-    "minimum-stability": "dev",
     "authors": [
         {
             "name": "Dmytro Karpovych",


### PR DESCRIPTION
when project set `"minimum-stability": "stable"`, run `composer require nullref/yii2-sb-admin-2 "*"`, will alert `could not be found in any version`
